### PR TITLE
Dynamic group

### DIFF
--- a/src/main/kotlin/com/example/Application.kt
+++ b/src/main/kotlin/com/example/Application.kt
@@ -1,10 +1,9 @@
 package com.example
 
 import com.example.api.configureRouting
-import com.example.domain.ErrorMessage
-import com.example.domain.MissingParameterException
-import com.example.domain.UnknownOperationException
+import com.example.domain.*
 import com.example.infrastructure.RatisHistoryManagement
+import com.example.raft.Constants
 import com.example.raft.HistoryRaftNode
 import io.ktor.application.*
 import io.ktor.features.*
@@ -13,11 +12,28 @@ import io.ktor.response.*
 import io.ktor.serialization.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
+import org.apache.ratis.protocol.RaftPeer
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.net.http.HttpRequest
+import java.net.http.HttpRequest.BodyPublishers
+import java.net.http.HttpResponse
+
 
 fun main(args: Array<String>) {
 
     val conf = getIdAndOffset(args)
-    val raftNode = HistoryRaftNode(conf.nodeId)
+    val configRaftPeer = Constants.PEERS.getOrNull(conf.nodeId)
+
+    val peerAndPeers: Pair<RaftPeer, List<RaftPeer>> = if (configRaftPeer == null) {
+        val leaderResponse = askLeader(conf.nodeId)
+        informLeader(leaderResponse.first)
+        leaderResponse
+    } else Pair(configRaftPeer, Constants.PEERS)
+
+
+    println("$peerAndPeers\n\n\n\n\n")
+    val raftNode = HistoryRaftNode(peerAndPeers.first, peerAndPeers.second)
     val historyManagement = RatisHistoryManagement(raftNode)
     embeddedServer(Netty, port = 8080 + conf.portOffset, host = "0.0.0.0") {
         install(ContentNegotiation) {
@@ -42,8 +58,36 @@ fun main(args: Array<String>) {
             }
         }
 
-        configureRouting(historyManagement)
+        configureRouting(historyManagement, raftNode)
     }.start(wait = true)
+}
+
+fun askLeader(nodeId: Int): Pair<RaftPeer, List<RaftPeer>> {
+    val leader = Constants.PEERS[0]
+    val request = HttpRequest.newBuilder().uri(URI.create("http://${leader.address}/config")).build()
+    val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+    val peers: List<RaftPeer> = objectMapper
+        .readValue(response.body(), ArrayList<HashMap<String, String>>().javaClass)
+        .map { RaftPeerDto.fromJson(it) }
+
+    val newPort = peers.last().address.split(":").last().toInt() + 1
+
+    val newPeer = RaftPeer.newBuilder().setId(nodeId.toString()).setAddress("localhost:${newPort}").build()
+
+    return Pair(newPeer, peers)
+}
+
+fun informLeader(raftPeer: RaftPeer) {
+    val leader = Constants.PEERS[0]
+    val request = HttpRequest
+        .newBuilder()
+        .uri(URI.create("http://${leader.address}/add_peer"))
+        .POST(BodyPublishers.ofString(objectMapper.writeValueAsString(raftPeer)))
+        .build()
+    val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+    LoggerFactory.getLogger(ChangeDto::class.java).info(response.body())
+
 }
 
 data class NodeIdAndPortOffset(
@@ -55,8 +99,9 @@ fun getIdAndOffset(args: Array<String>): NodeIdAndPortOffset {
     if (args.isNotEmpty()) {
         return NodeIdAndPortOffset(nodeId = args[0].toInt(), portOffset = args[0].toInt())
     }
-    
-    val id = System.getenv()["RAFT_NODE_ID"]?.toInt() ?: throw RuntimeException("Provide either arg or RAFT_NODE_ID env variable to represent id of node")
+
+    val id = System.getenv()["RAFT_NODE_ID"]?.toInt()
+        ?: throw RuntimeException("Provide either arg or RAFT_NODE_ID env variable to represent id of node")
 
     return NodeIdAndPortOffset(nodeId = id, portOffset = 0)
 }

--- a/src/main/kotlin/com/example/Application.kt
+++ b/src/main/kotlin/com/example/Application.kt
@@ -1,9 +1,11 @@
 package com.example
 
 import com.example.api.configureRouting
-import com.example.domain.*
+import com.example.domain.ErrorMessage
+import com.example.domain.MissingParameterException
+import com.example.domain.RaftPeerDto
+import com.example.domain.UnknownOperationException
 import com.example.infrastructure.RatisHistoryManagement
-import com.example.raft.Constants
 import com.example.raft.HistoryRaftNode
 import io.ktor.application.*
 import io.ktor.features.*
@@ -12,30 +14,16 @@ import io.ktor.response.*
 import io.ktor.serialization.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
-import org.apache.ratis.protocol.RaftPeer
-import org.slf4j.LoggerFactory
-import java.net.URI
-import java.net.http.HttpRequest
-import java.net.http.HttpRequest.BodyPublishers
-import java.net.http.HttpResponse
 
 
 fun main(args: Array<String>) {
 
-    val conf = getIdAndOffset(args)
-    val configRaftPeer = Constants.PEERS.getOrNull(conf.nodeId)
+    val config = ConfigStore(args)
 
-    val peerAndPeers: Pair<RaftPeer, List<RaftPeer>> = if (configRaftPeer == null) {
-        val leaderResponse = askLeader(conf.nodeId)
-        informLeader(leaderResponse.first)
-        leaderResponse
-    } else Pair(configRaftPeer, Constants.PEERS)
+    var raftNode = HistoryRaftNode(config.peer.toRaftPeer(), config.peers.toRaftPeers())
+    var historyManagement = RatisHistoryManagement(raftNode)
 
-
-    println("$peerAndPeers\n\n\n\n\n")
-    val raftNode = HistoryRaftNode(peerAndPeers.first, peerAndPeers.second)
-    val historyManagement = RatisHistoryManagement(raftNode)
-    embeddedServer(Netty, port = 8080 + conf.portOffset, host = "0.0.0.0") {
+    embeddedServer(Netty, port = config.insidePort, host = "0.0.0.0") {
         install(ContentNegotiation) {
             json()
         }
@@ -50,58 +38,10 @@ fun main(args: Array<String>) {
                     ErrorMessage("Unknown operation to perform: ${cause.desiredOperationName}")
                 )
             }
-            exception<Throwable> { cause ->
-                call.respond(
-                    status = HttpStatusCode.InternalServerError,
-                    ErrorMessage("UnexpectedError, $cause")
-                )
-            }
         }
 
-        configureRouting(historyManagement, raftNode)
+        configureRouting(historyManagement, raftNode, config.peers)
     }.start(wait = true)
 }
 
-fun askLeader(nodeId: Int): Pair<RaftPeer, List<RaftPeer>> {
-    val leader = Constants.PEERS[0]
-    val request = HttpRequest.newBuilder().uri(URI.create("http://${leader.address}/config")).build()
-    val response = client.send(request, HttpResponse.BodyHandlers.ofString())
-    val peers: List<RaftPeer> = objectMapper
-        .readValue(response.body(), ArrayList<HashMap<String, String>>().javaClass)
-        .map { RaftPeerDto.fromJson(it) }
-
-    val newPort = peers.last().address.split(":").last().toInt() + 1
-
-    val newPeer = RaftPeer.newBuilder().setId(nodeId.toString()).setAddress("localhost:${newPort}").build()
-
-    return Pair(newPeer, peers)
-}
-
-fun informLeader(raftPeer: RaftPeer) {
-    val leader = Constants.PEERS[0]
-    val request = HttpRequest
-        .newBuilder()
-        .uri(URI.create("http://${leader.address}/add_peer"))
-        .POST(BodyPublishers.ofString(objectMapper.writeValueAsString(raftPeer)))
-        .build()
-    val response = client.send(request, HttpResponse.BodyHandlers.ofString())
-
-    LoggerFactory.getLogger(ChangeDto::class.java).info(response.body())
-
-}
-
-data class NodeIdAndPortOffset(
-    val nodeId: Int,
-    val portOffset: Int
-)
-
-fun getIdAndOffset(args: Array<String>): NodeIdAndPortOffset {
-    if (args.isNotEmpty()) {
-        return NodeIdAndPortOffset(nodeId = args[0].toInt(), portOffset = args[0].toInt())
-    }
-
-    val id = System.getenv()["RAFT_NODE_ID"]?.toInt()
-        ?: throw RuntimeException("Provide either arg or RAFT_NODE_ID env variable to represent id of node")
-
-    return NodeIdAndPortOffset(nodeId = id, portOffset = 0)
-}
+fun List<RaftPeerDto>.toRaftPeers() = this.map { it.toRaftPeer() }

--- a/src/main/kotlin/com/example/ConfigStore.kt
+++ b/src/main/kotlin/com/example/ConfigStore.kt
@@ -1,0 +1,113 @@
+package com.example
+
+import com.example.domain.RaftPeerDto
+import com.example.raft.Constants
+import org.slf4j.LoggerFactory
+import java.net.ConnectException
+import java.net.URI
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+
+class ConfigStore(args: Array<String>) {
+
+    val nodeId: Int
+    val insidePort: Int
+    private val outsidePort: Int
+    val peer: RaftPeerDto
+    val peers: List<RaftPeerDto>
+    private val startPortNumber: Int = 8080
+
+    init {
+        val conf = getIdAndOffset(args)
+        nodeId = conf.first
+        insidePort = startPortNumber + conf.second
+        outsidePort = startPortNumber + conf.first
+        val configRaftPeer = Constants.PEERS_DTO.getOrNull(nodeId)
+        if (configRaftPeer == null) {
+            val leaderResponse = askLeader(nodeId)
+            peer = leaderResponse.first
+            informPeers(peer, leaderResponse.second)
+            peers = leaderResponse.second.plus(peer)
+        } else {
+            peer = configRaftPeer
+            peers = Constants.PEERS_DTO
+        }
+    }
+
+
+    private fun askLeader(nodeId: Int): Pair<RaftPeerDto, List<RaftPeerDto>> {
+
+        val response = sendToRunningLeader { leader ->
+            HttpRequest.newBuilder()
+                .uri(URI.create("http://${leader}/config"))
+                .build()
+        } ?: throw Exception("None of config servers is running")
+
+        val peers: List<RaftPeerDto> = objectMapper
+            .readValue(response.body(), ArrayList<HashMap<String, String>>().javaClass)
+            .map { RaftPeerDto.fromJson(it) }
+
+        val allPorts = peers.map { it.getPort() }
+
+        val newPort = findPort(allPorts)
+
+        val newPeer =
+            RaftPeerDto(nodeId.toString(), localhostAddress(newPort), localhostAddress(outsidePort))
+        return Pair(newPeer, peers)
+    }
+
+    private fun sendToRunningLeader(fn: (address: String) -> HttpRequest): HttpResponse<String>? {
+        for (leader in Constants.PEERS_DTO) {
+            val request = fn(leader.httpAddress)
+            val response = tryCatchSend(request, leader.address)
+            if (response != null && response.statusCode() == 200) return response
+        }
+        return null
+    }
+
+    private fun localhostAddress(portNum: Int): String = "127.0.0.1:$portNum"
+
+    private fun findPort(allPorts: List<Int>): Int = findPort(allPorts.last() + 1, allPorts)
+
+    private fun findPort(portNum: Int, allPorts: List<Int>): Int =
+        if (allPorts.contains(portNum)) findPort(portNum + 1, allPorts)
+        else portNum
+
+    private fun informPeers(raftPeerDto: RaftPeerDto, peers: List<RaftPeerDto>) {
+        var anyAccept = false
+        for (leader in peers) {
+            val request = HttpRequest
+                .newBuilder()
+                .uri(URI.create("http://${leader.httpAddress}/add_peer"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(raftPeerDto)))
+                .build()
+            val response = tryCatchSend(request, leader.httpAddress)
+            if (response?.statusCode() != 200) logger.error("Leader $leader response with $response\n ${response?.body()?:"Nothing"}")
+            if(response?.statusCode() == 200)anyAccept = true
+        }
+        if(!anyAccept) throw Exception("All peers rejected me")
+    }
+
+    private fun tryCatchSend(request: HttpRequest, address: String): HttpResponse<String>? =
+        try {
+            client.send(request, HttpResponse.BodyHandlers.ofString())
+        } catch (e: ConnectException) {
+            logger.error("Address $address is closed")
+            null
+        }
+
+    private fun getIdAndOffset(args: Array<String>): Pair<Int, Int> =
+        if (args.isNotEmpty()) Pair(args[0].toInt(), args[0].toInt())
+        else System
+            .getenv()["RAFT_NODE_ID"]
+            ?.toInt()
+            ?.let { Pair(it, 0) }
+            ?: throw RuntimeException("Provide either arg or RAFT_NODE_ID env variable to represent id of node")
+
+    companion object {
+        val logger = LoggerFactory.getLogger(this::class.java)
+    }
+}
+

--- a/src/main/kotlin/com/example/api/Routing.kt
+++ b/src/main/kotlin/com/example/api/Routing.kt
@@ -3,13 +3,16 @@ package com.example.api
 import com.example.domain.ChangeDto
 import com.example.domain.ErrorMessage
 import com.example.domain.HistoryManagement
+import com.example.domain.RaftPeerDto
 import com.example.objectMapper
+import com.example.raft.RaftNode
 import io.ktor.application.*
 import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
+import org.apache.ratis.protocol.RaftPeer
 
-fun Application.configureRouting(historyManagement: HistoryManagement) {
+fun Application.configureRouting(historyManagement: HistoryManagement, raftNode: RaftNode) {
 
     // Starting point for a Ktor app:
     routing {
@@ -23,6 +26,17 @@ fun Application.configureRouting(historyManagement: HistoryManagement) {
             call.respond((result ?: ErrorMessage("Error")).let { objectMapper.writeValueAsString(it) })
         }
 
+        get("/config"){
+            val peers = raftNode.getPeersGroups()
+            call.respond(peers.let { objectMapper.writeValueAsString(it) })
+        }
+
+        post("/add_peer"){
+            val peer = RaftPeerDto.fromJson(call.receive())
+            raftNode.addPeer(peer)
+            val peers = raftNode.getPeersGroups()
+            call.respond(peers.let { objectMapper.writeValueAsString(it) })
+        }
+
     }
 }
-

--- a/src/main/kotlin/com/example/config.kt
+++ b/src/main/kotlin/com/example/config.kt
@@ -1,10 +1,11 @@
 package com.example
 
+import com.example.domain.RaftPeerDto
 import com.sksamuel.hoplite.ConfigLoader
 
 data class Config(val raft: RaftConfig)
 data class RaftConfig(val server: ServerConfig, val clusterGroupId: String)
-data class ServerConfig(val addresses: List<String>, val root: RootConfig)
+data class ServerConfig(val peers: List<RaftPeerDto>, val root: RootConfig)
 data class RootConfig(val storage: StorageConfig)
 data class StorageConfig(val path: String)
 

--- a/src/main/kotlin/com/example/domain/RaftPeer.kt
+++ b/src/main/kotlin/com/example/domain/RaftPeer.kt
@@ -1,0 +1,8 @@
+package com.example.domain
+
+import org.apache.ratis.protocol.RaftPeer
+
+object RaftPeerDto {
+    fun fromJson(json: Map<String, String>): RaftPeer =
+        RaftPeer.newBuilder().setId(json["peerId"]).setAddress(json["address"]).build()
+}

--- a/src/main/kotlin/com/example/domain/RaftPeer.kt
+++ b/src/main/kotlin/com/example/domain/RaftPeer.kt
@@ -2,7 +2,14 @@ package com.example.domain
 
 import org.apache.ratis.protocol.RaftPeer
 
-object RaftPeerDto {
-    fun fromJson(json: Map<String, String>): RaftPeer =
-        RaftPeer.newBuilder().setId(json["peerId"]).setAddress(json["address"]).build()
+
+data class RaftPeerDto(val peerId: String, val address: String, val httpAddress: String) {
+    companion object {
+        fun fromJson(json: Map<String, String>): RaftPeerDto =
+            RaftPeerDto(json["peerId"]!!, json["address"]!!, json["httpAddress"]!!)
+    }
+
+    fun toRaftPeer(): RaftPeer = RaftPeer.newBuilder().setId(peerId).setAddress(address).build()
+
+    fun getPort() = address.split(":").last().toInt()
 }

--- a/src/main/kotlin/com/example/domain/exceptions.kt
+++ b/src/main/kotlin/com/example/domain/exceptions.kt
@@ -3,4 +3,5 @@ package com.example.domain
 class MissingParameterException(message: String?) : Exception(message)
 class UnknownOperationException(val desiredOperationName: String) : Exception()
 
+@kotlinx.serialization.Serializable
 data class ErrorMessage(val msg: String)

--- a/src/main/kotlin/com/example/raft/Constants.kt
+++ b/src/main/kotlin/com/example/raft/Constants.kt
@@ -1,5 +1,6 @@
 package com.example.raft
 
+import com.example.domain.RaftPeerDto
 import com.example.loadConfig
 import org.apache.ratis.protocol.RaftGroup
 import org.apache.ratis.protocol.RaftGroupId
@@ -15,13 +16,13 @@ object Constants {
     val PATH: String
     val CLUSTER_GROUP_ID: UUID
     val RAFT_GROUP: RaftGroup
+    val PEERS_DTO: List<RaftPeerDto>
 
     init {
         val config = loadConfig("/${System.getenv("CONFIG_FILE") ?: "application.conf"}")
         PATH = config.raft.server.root.storage.path
-        PEERS = config.raft.server.addresses.mapIndexed { index, address ->
-            RaftPeer.newBuilder().setId("n$index").setAddress(address).build()
-        }
+        PEERS_DTO = config.raft.server.peers
+        PEERS = PEERS_DTO.map { it.toRaftPeer() }
         CLUSTER_GROUP_ID = UUID.fromString(config.raft.clusterGroupId)
         RAFT_GROUP = createRaftGroups()
     }

--- a/src/main/kotlin/com/example/raft/Constants.kt
+++ b/src/main/kotlin/com/example/raft/Constants.kt
@@ -6,25 +6,6 @@ import org.apache.ratis.protocol.RaftGroupId
 import org.apache.ratis.protocol.RaftPeer
 import java.util.*
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-
 
 /**
  * Constants across servers and clients
@@ -42,7 +23,7 @@ object Constants {
             RaftPeer.newBuilder().setId("n$index").setAddress(address).build()
         }
         CLUSTER_GROUP_ID = UUID.fromString(config.raft.clusterGroupId)
-        RAFT_GROUP = RaftGroup.valueOf(RaftGroupId.valueOf(CLUSTER_GROUP_ID), PEERS)
+        RAFT_GROUP = createRaftGroups()
     }
 
     fun oneNodeGroup(peer: RaftPeer): RaftGroup {
@@ -50,4 +31,7 @@ object Constants {
             RaftGroupId.valueOf(CLUSTER_GROUP_ID), peer
         )
     }
+
+    fun createRaftGroups(peers: List<RaftPeer> = PEERS): RaftGroup =
+        RaftGroup.valueOf(RaftGroupId.valueOf(CLUSTER_GROUP_ID), peers)
 }

--- a/src/main/kotlin/com/example/raft/HistoryRaftNode.kt
+++ b/src/main/kotlin/com/example/raft/HistoryRaftNode.kt
@@ -3,12 +3,13 @@ package com.example.raft
 import com.example.domain.*
 import com.example.infrastructure.RatisHistoryManagement
 import com.example.objectMapper
+import org.apache.ratis.protocol.RaftPeer
 import org.slf4j.LoggerFactory
 import java.io.Closeable
 import java.io.File
 
-class HistoryRaftNode(peerId: Int) :
-    RaftNode(peerId, HistoryStateMachine(), File("./history-$peerId")),
+class HistoryRaftNode(raftPeer: RaftPeer, peers: List<RaftPeer>) :
+    RaftNode(raftPeer, HistoryStateMachine(), peers),
     ConsensusProtocol<Change, History> {
 
     override fun proposeChange(change: Change): ConsensusResult {

--- a/src/main/kotlin/com/example/utils.kt
+++ b/src/main/kotlin/com/example/utils.kt
@@ -1,5 +1,7 @@
 package com.example
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import java.net.http.HttpClient
 
 val objectMapper = jacksonObjectMapper()
+val client = HttpClient.newBuilder().build()

--- a/src/main/resources/application-compose.conf
+++ b/src/main/resources/application-compose.conf
@@ -5,6 +5,11 @@ raft {
             "peer2:10124",
             "peer3:11124"
         ]
+        httpAddresses = [
+            "peer1:8081",
+            "peer1:8082",
+            "peer1:8083"
+            ]
         root {
             storage {
                 path = "./raft-examples/target"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,9 +1,20 @@
 raft {
     server {
-        addresses = [
-            "127.0.0.1:10024",
-            "127.0.0.1:10124",
-            "127.0.0.1:11124"
+        peers = [
+            {
+                peerId: "n1",
+                address: "127.0.0.1:10024",
+                httpAddress: "127.0.0.1:8081"
+            },
+            {
+                peerId: "n2",
+                address: "127.0.0.1:10124",
+                httpAddress: "127.0.0.1:8082"
+            },            {
+                peerId: "n3",
+                address: "127.0.0.1:11124",
+                httpAddress: "127.0.0.1:8083"
+            },
         ]
         root {
             storage {


### PR DESCRIPTION
In this PR three I tried to implement two features: rejecting consensus propose and dynamic adding node to raft group. I failed in both tasks. I will summarize in short results.

#### Rejecting consensus propose
Ratis library API doesn't allow each node to decide, if they accept or reject consensus proposition. I also try to hack it, by changing implementation of making change of state machine state. I thought that change is made in each followers the same way it is made in leader. But after many tries it comes out that change is propageted different way or leader doesn't propagate change, but the whole new state to followers.

#### Dynamic adding node to raft group
Also Ratis library API doesn't allow to change configuration of raft server. Tries of hacking it leads to strange bugs like infinite loop of sending same message. The furthest progress was when it looked like the connection between the configuration node and dynamic node was made, but this connection wasn't stable enough to allow us to make any operation.


#### Summary
These experiences raise the question, of whether we shouldn't look for another library for consensus protocol. 