### PR TITLE
add experiment label to tempo generated metrics

### DIFF
--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -174,6 +174,7 @@ func DoInit(namespace string, createNamespace bool) {
 			"reportingEnabled": false,
 			"global_overrides": map[string]interface{}{
 				"max_traces_per_user": 0,
+				"metrics_generator_processor_span_metrics_dimensions": []string{"experiment"},
 			},
 		},
 	}


### PR DESCRIPTION
Tempo allows to generate metrics from spans, yet out of the box we wouldn't have a way to determine which metrics come from which experiment, if multiple experiments are run at the same time. This PR adds the "experiment" label (which is displayed upon the start of `perform command`) to tempo generated metrics, so we can distinct between experiments.