### PR TITLE
own proxy v2

### DIFF
--- a/misc/proxy/Dockerfile
+++ b/misc/proxy/Dockerfile
@@ -1,0 +1,23 @@
+FROM openresty/openresty:alpine
+
+RUN	apk --update add --no-cache --virtual .gettext gettext
+
+ADD proxy.conf /etc/nginx/conf.d/proxy.tmpl
+
+ENV LIMIT                0
+ENV DELAY                0.0
+ENV UPSTREAM             http://www.example.com
+ENV RESOLVER             8.8.8.8
+ENV START_DELAY 0
+ENV END_DELAY 0
+ENV MY_PEERSET_START_DELAY 0
+ENV MY_PEERSET_END_DELAY 0
+ENV NOT_MY_PEERSET_START_DELAY 0
+ENV NOT_MY_PEERSET_END_DELAY 0
+ENV MY_PEERSET_DELAY 0
+ENV NOT_MY_PEERSET_DELAY 0
+
+CMD /bin/ash -c " \
+        envsubst '\${LIMIT} \${UPSTREAM} \${DELAY} \${RESOLVER} \${PEERSET_ID} \${TYPE} \${START_DELAY} \${END_DELAY} \${MY_PEERSET_START_DELAY} \${MY_PEERSET_END_DELAY} \${NOT_MY_PEERSET_START_DELAY} \${NOT_MY_PEERSET_END_DELAY} \${MY_PEERSET_DELAY} \${NOT_MY_PEERSET_DELAY} \${FIXED_DELAY}' \
+                 < /etc/nginx/conf.d/proxy.tmpl > /etc/nginx/conf.d/default.conf \
+        && nginx -g 'daemon off;'"

--- a/misc/proxy/proxy.conf
+++ b/misc/proxy/proxy.conf
@@ -43,10 +43,10 @@ server {
         set $result "F";
     }
 
-    if ( $arg_peerset = ${PEERSET_ID} ) {
+    if ( $arg_sender = ${PEERSET_ID} ) {
         set $result "${result}M";
     }
-    if ( $arg_peerset != ${PEERSET_ID} ) {
+    if ( $arg_sender != ${PEERSET_ID} ) {
         set $result "${result}N";
     }
 

--- a/misc/proxy/proxy.conf
+++ b/misc/proxy/proxy.conf
@@ -1,0 +1,81 @@
+resolver ${RESOLVER};
+
+init_worker_by_lua_block {
+    local resty_random = require('resty.random')
+    -- use random byte (0..255 int) as a seed
+    local seed = string.byte(resty_random.bytes(1))
+    math.randomseed(seed)
+}
+
+map $TYPE $type {
+    default   "";
+    FIXED_DELAY "fixed";
+    RANDOM_DELAY "random";
+    PEERSET_BASED_RANDOM_DELAY "peerset_random";
+    PEERSET_BASED_FIXED_DELAY "peerset_fixed";
+}
+
+server {
+    listen 8080;
+
+    limit_rate ${LIMIT};
+
+    set $calculated_delay 0;
+
+    # type = instant, fixed_delay, random_delay, peerset_based_random_delay, peerset_based_fixed_delay
+    if ( $type = "fixed" ) {
+        set $calculated_delay ${DELAY};
+    }
+
+    if ( $type = "random" ) {
+        set_by_lua_block $random {
+            return math.random(${START_DELAY}, ${END_DELAY})
+        }
+        set $calculated_delay $random;
+    }
+
+
+    if ( $type = "peerset_random" ) {
+        set $result "R";
+    }
+
+    if ( $type = "peerset_fixed" ) {
+        set $result "F";
+    }
+
+    if ( $arg_peerset = ${PEERSET_ID} ) {
+        set $result "${result}M";
+    }
+    if ( $arg_peerset != ${PEERSET_ID} ) {
+        set $result "${result}N";
+    }
+
+    if ( $result = RM ) {
+        # random, my peerset
+        set_by_lua_block $calculated_delay {
+            return math.random(${MY_PEERSET_START_DELAY}, ${MY_PEERSET_END_DELAY})
+        }
+    }
+
+    if ( $result = FM ) {
+        # fixed, my peerset
+        set $calculated_delay ${MY_PEERSET_DELAY};
+    }
+
+    if ( $result = RN ) {
+        # random, not my peerset
+        set_by_lua_block $calculated_delay {
+            return math.random(${NOT_MY_PEERSET_START_DELAY}, ${NOT_MY_PEERSET_END_DELAY})
+        }
+    }
+
+    if ( $result = FN ) {
+        # fixed, not my peerset
+        set $calculated_delay ${NOT_MY_PEERSET_DELAY};
+    }
+
+    location / {
+        access_by_lua 'ngx.sleep(tonumber(ngx.var.calculated_delay))';
+        proxy_pass ${UPSTREAM}/;
+    }
+}


### PR DESCRIPTION
Our version of the proxy supports five different types of delay:
* instant (no delay, by default)
* fixed delay - always the same
* random delay - always random number (no matter the peerset)
* peerset based fixed delay - if in the same peerset, use one delay, if from outside of peerset - use another
* peerset based random delay - if in the same peerset, use one set of random numbers, if from outside of peerset - use another

I don't know if it's possible (and cost-effective) to handle situations where some peersets are closer and some are further away (especially considering that nginx does not even support nested ifs :smile:)